### PR TITLE
25 implement duration as a subtype of number

### DIFF
--- a/src/duration.jl
+++ b/src/duration.jl
@@ -7,7 +7,7 @@ fractional part.
 
 ### Fields
 - `seconds`: The integer number of seconds.
-- `fraction`: The fractional part of the duration, where `T` is a subtype of `Real`.
+- `fraction`: The fractional part of the duration, where `T` is a subtype of `Number`.
 """
 struct Duration{T} <: Number 
     seconds::Int 

--- a/src/duration.jl
+++ b/src/duration.jl
@@ -29,6 +29,10 @@ value(d::Duration{T}) where T = d.seconds + d.fraction
 # ---
 # Type Conversions and Promotions 
 
+function Base.convert(::Type{Duration{T}}, d::Duration{S}) where {T,S}
+    return Duration(d.seconds, convert(T, d.fraction))
+end
+
 function Base.convert(::Type{T}, d::Duration{S}) where {T<:Number,S}
     return Duration(d.seconds, convert(T, d.fraction))
 end

--- a/src/epoch.jl
+++ b/src/epoch.jl
@@ -70,8 +70,8 @@ struct Epoch{S,T}
 end
 
 function Epoch{S}(seconds::Number) where {S<:AbstractTimeScale}
-    sec, frac = divrem(seconds, 1)    
-    return Epoch{S, typeof(frac)}(S(), Duration(Int(sec), frac))
+    d = Duration(seconds)
+    return Epoch{S, ftype(d)}(S(), d)
 end
 
 Epoch(sec::Number, ::S) where {S<:AbstractTimeScale} = Epoch{S}(sec)
@@ -83,7 +83,7 @@ Epoch(dt::DateTime, ::Type{S}) where {S<:AbstractTimeScale} = Epoch{S}(j2000s(dt
 Epoch(e::Epoch) = e
 
 Epoch{S,T}(e::Epoch{S,T}) where {S,T} = e
-Epoch{S,T}(e::Epoch{S,N}) where {S, N, T} = Epoch{S}(T(j2000s(e)))
+Epoch{S,T}(e::Epoch{S,N}) where {S, N, T} = Epoch{S,T}(e.scale, convert(T, e.dur))
 
 # Construct an epoch from an ISO string and a scale
 function Epoch(s::AbstractString, scale::S) where {S <: AbstractTimeScale}
@@ -91,7 +91,7 @@ function Epoch(s::AbstractString, scale::S) where {S <: AbstractTimeScale}
 
     # TODO: the precision of this could be improved
     _, jd2 = calhms2jd(y, m, d, H, M, sec + sf)
-    return Epoch(jd2 * 86400, scale)
+    return Epoch(jd2 * DAY2SEC, scale)
 end
 
 # Construct an epoch from an ISO string
@@ -201,21 +201,8 @@ function Base.:-(::Epoch{S1}, ::Epoch{S2}) where {S1, S2}
     throw(ErrorException("only epochs defined in the same timescale can be subtracted."))
 end 
 
-function Base.:+(e::Epoch{S, N}, x::Number) where {S, N}
-    return Epoch{S, N}(timescale(e), e.dur + x)
-end
-
-function Base.:-(e::Epoch{S, N}, x::Number) where {S, N}
-    return Epoch{S, N}(timescale(e), e.dur - x)
-end
-
-function Base.:+(e::Epoch{S, N}, d::Duration{<:Number}) where {S, N}
-    return Epoch{S, N}(timescale(e), e.dur + d)
-end
-
-function Base.:-(e::Epoch{S, N}, d::Duration{<:Number}) where {S, N}
-    return Epoch{S, N}(timescale(e), e.dur - d)
-end
+Base.:+(e::Epoch, x::Number) = Epoch(timescale(e), e.dur + x)
+Base.:-(e::Epoch, x::Number) = Epoch(timescale(e), e.dur - x)
 
 function (::Base.Colon)(start::Epoch, step::Number, stop::Epoch)
     step = start < stop ? step : -step

--- a/src/epoch.jl
+++ b/src/epoch.jl
@@ -214,6 +214,9 @@ function (::Base.Colon)(start::Epoch, step::Duration, stop::Epoch)
     return (:)(start, value(step), stop)
 end
 
+(::Base.Colon)(start::Epoch, stop::Epoch) = (:)(start, 86400, stop)
+
+
 Base.isless(e1::Epoch{S}, e2::Epoch{S}) where {S} = e1.dur < e2.dur
 
 function Base.isapprox(e1::Epoch{S}, e2::Epoch{S}; kwargs...) where {S}

--- a/test/Tempo/duration.jl
+++ b/test/Tempo/duration.jl
@@ -1,6 +1,7 @@
 
 # TestSet for Duration
 @testset "Duration" begin
+
     # Test Duration constructor with a floating point number
     d1 = Duration(5.75)
     @test d1.seconds == 5
@@ -11,9 +12,24 @@
     @test d2.seconds == 10
     @test d2.fraction == 0.25
 
+    # Check Constructor with a Big Float
+    db1 = Duration(BigFloat(2.5422))
+
+    @test db1.seconds == 2 
+    @test db1.fraction ≈ 0.5422 atol=1e-14 rtol=1e-14
+
+    # Test duration type 
+    @test Tempo.ftype(db1) == BigFloat
+
     # Test value function
     @test value(d1) == 5.75
     @test value(d2) == 10.25
+
+    # Test duration conversion 
+    db2 = convert(BigFloat, d1)
+    @test Tempo.ftype(db2) == BigFloat 
+    @test db2.seconds == 5 
+    @test db2.fraction ≈ 0.75 atol=1e-14 rtol=1e-14
 
     # Test isless with a number
     @test d1 < 6.0 
@@ -63,4 +79,5 @@
     @test d10.fraction == d1.fraction
     @test d11.seconds == d1.seconds
     @test d11.fraction == d1.fraction
+
 end

--- a/test/Tempo/epoch.jl
+++ b/test/Tempo/epoch.jl
@@ -68,8 +68,10 @@
     @test_throws ErrorException e3-e1
 
     ems = e1:86400:e2 
+    ems2 = e1:e2 
     for j = 2:lastindex(ems)
         @test ems[j] == e1 + 86400*(j-1)
+        @test ems2[j] == e1 + 86400*(j-1)
     end
 
     # Based on Vallado "Fundamental of astrodynamics" page 196


### PR DESCRIPTION
@andreapasquale94 let's discuss whether these could be usefull changes: 

1. Duration has been made a chlild of Number. The constructors have been reworked to avoid code repetitions. The constructor ```Duration(sec::Int, frac::T)``` has been removed since it equals the default type constructor.
2. `Base.convert` and `Base.promote_rule` have been implemented for `Duration`. Currently `Base.convert` can be used in two ways (although the first option could be removed):
```julia
julia> d = Duration(1)
Duration{Int64}(1, 0)

julia> convert(Float64, d)
Duration{Float64}(1, 0.0)

julia> convert(Duration{Float64}, d)
Duration{Float64}(1, 0.0)
```


3. The `ftype` function has been added to retrieve the type in which the fractional part of the `Duration` is represented. 

4. `Epoch` constructors have also been updated to reflect the above changes and avoid code repetitions. 
5. Addition and subtraction implementations of `Epoch` have been simplified. Additionally, they now properly propagate types. In the previous implementation, summing an epoch of type `Epoch{TDB, Float64}` with a duration or number of type `BigFloat` would improperly return an epoch in `Float64` representation, leading to a loss in accuracy. Now, the result is expressed using the highest accuracy type (i.e., the one resulting from the `promote_rule` operation).
6. The step length operation to generate a range of epochs with a daily step range has been re-implemented. Thus ```ep1:ep2``` now properly works again.
 
Note that even though `Duration` is a subtype of `Number`, all operations that have not been defined, i.e., multiplication and division, will return an error upon execution. 